### PR TITLE
removes deprected ansible apt loop syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,8 @@
 
 - name: Install apt packages
   apt:
-    pkg: '{{ item }}'
     state: present
-  with_items: '{{ sury_apt_packages }}'
+    pkg: '{{ sury_apt_packages }}'
   when: sury_apt_packages is defined and sury_apt_packages|length
 
 - name: Install sury key


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `pkg: {{ 
item }}`, please use `pkg: '{{ sury_apt_packages }}'` and remove the loop. This feature will be removed in version 2.11. 